### PR TITLE
FEAT (feat/4): Modify drizzle service to work without production  credentials

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,4 @@
-ENVIRONMENT="DEV or PRD"
-TURSO_DATABASE_URL=""
-TURSO_AUTH_TOKEN=""
-LOCAL_DATABASE_URL="./drizzle/sqlite.db"
+ENVIRONMENT= # Only two options, not required: DEV or PRD. By default is DEV
+TURSO_DATABASE_URL= # Required only with PRD environment
+TURSO_AUTH_TOKEN= # Required only with PRD environment
+LOCAL_DATABASE_URL="./drizzle/sqlite.db" #Dont modify

--- a/config/joi.validations.ts
+++ b/config/joi.validations.ts
@@ -2,7 +2,7 @@ import * as Joi from 'joi';
 
 export const JoiValidationSchema = Joi.object({
   ENVIRONMENT: Joi.string().default('DEV'),
-  TURSO_DATABASE_URL: Joi.string().required(),
-  TURSO_AUTH_TOKEN: Joi.string().required(),
+  TURSO_DATABASE_URL: Joi.string(),
+  TURSO_AUTH_TOKEN: Joi.string(),
   LOCAL_DATABASE_URL: Joi.string().default('./drizzle/sqlite.db'),
 });

--- a/src/category/repositories/drizzle-category.repository.ts
+++ b/src/category/repositories/drizzle-category.repository.ts
@@ -26,7 +26,7 @@ export class DrizzleCategoryRepository
   constructor(private readonly drizzleService: DrizzleService) {}
 
   onModuleInit() {
-    this.db = this.drizzleService.getClient();
+    this.db = this.drizzleService.getClient(DrizzleCategoryRepository.name);
   }
 
   async create(createCategoryDto: CreateCategoryDto): Promise<Category> {

--- a/src/product/repositories/drizzle-product.repository.ts
+++ b/src/product/repositories/drizzle-product.repository.ts
@@ -26,7 +26,7 @@ export class DrizzleProductRepository
   constructor(private readonly drizzleService: DrizzleService) {}
 
   onModuleInit() {
-    this.db = this.drizzleService.getClient();
+    this.db = this.drizzleService.getClient(DrizzleProductRepository.name);
   }
 
   async create(createProductDto: CreateProductDto): Promise<Product> {

--- a/src/seed/repositories/drizzle-seed.repository.ts
+++ b/src/seed/repositories/drizzle-seed.repository.ts
@@ -17,7 +17,7 @@ export class DrizzleSeedRepository implements SeedRepository, OnModuleInit {
   constructor(private readonly drizzleService: DrizzleService) {}
 
   onModuleInit() {
-    this.db = this.drizzleService.getClient();
+    this.db = this.drizzleService.getClient(DrizzleSeedRepository.name);
   }
 
   async cleanDatabaseRecords(): Promise<void> {

--- a/src/setting/repositories/drizzle-setting.repository.ts
+++ b/src/setting/repositories/drizzle-setting.repository.ts
@@ -26,7 +26,7 @@ export class DrizzleSettingRepository
   constructor(private drizzleService: DrizzleService) {}
 
   onModuleInit() {
-    this.db = this.drizzleService.getClient();
+    this.db = this.drizzleService.getClient(DrizzleSettingRepository.name);
   }
 
   async create(createSettingDto: CreateSettingDto): Promise<Setting> {

--- a/src/user/repositories/drizzle-user.repository.ts
+++ b/src/user/repositories/drizzle-user.repository.ts
@@ -26,7 +26,7 @@ export default class DrizzleUserRepository
   constructor(private readonly drizzleService: DrizzleService) {}
 
   onModuleInit() {
-    this.db = this.drizzleService.getClient();
+    this.db = this.drizzleService.getClient(DrizzleUserRepository.name);
   }
 
   async create(createUserDto: CreateUserDto): Promise<User> {


### PR DESCRIPTION
Cambios realizados sobre el módulo Drizzle para evitar la inicialización de la conexión con la base de datos de desarrollo y producción a la vez.
También se agregaron logs para saber si se pudo conectar correctamente a la base de datos de desarrollo y se agregó un nuevo parámetro para recibir el nombre de la clase y especificar en que clase se realizó la conexión (se modifico el consumo del método en todos los repositorios).